### PR TITLE
Add storage explorer link for transfers to Azure Storage containers

### DIFF
--- a/src/assets/config/app.config.json
+++ b/src/assets/config/app.config.json
@@ -1,6 +1,8 @@
 {
-  "apiKey": "NwLx%6ICreX(GT]e",
-  "catalogUrl": "http://paul12-company1-edc-mvd.northeurope.azurecontainer.io:8181/api/federatedcatalog",
-  "dataManagementApiUrl": "http://paul12-company1-edc-mvd.northeurope.azurecontainer.io:9191/api/v1/data",
-  "storageAccount": "paul12company1inbox"
+  "_comment": "This file will be replaced at runtime when deployed to the cloud",
+  "dataManagementApiUrl": "{{dataManagementApiUrl}}",
+  "catalogUrl": "{{catalogUrl}}",
+  "storageAccount": "{{account}}",
+  "storageExplorerLinkTemplate": "storageexplorer://v=1&accountid=/subscriptions/{{subscription}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Storage/storageAccounts/{{account}}&subscriptionid={{subscriptionId}}&resourcetype=Azure.BlobContainer&resourcename={{container}}",
+  "apiKey": "{{apiKey}}"
 }

--- a/src/assets/config/app.config.json
+++ b/src/assets/config/app.config.json
@@ -3,6 +3,6 @@
   "dataManagementApiUrl": "{{dataManagementApiUrl}}",
   "catalogUrl": "{{catalogUrl}}",
   "storageAccount": "{{account}}",
-  "storageExplorerLinkTemplate": "storageexplorer://v=1&accountid=/subscriptions/{{subscription}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Storage/storageAccounts/{{account}}&subscriptionid={{subscriptionId}}&resourcetype=Azure.BlobContainer&resourcename={{container}}",
+  "storageExplorerLinkTemplate": "storageexplorer://v=1&accountid=/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Storage/storageAccounts/{{account}}&subscriptionid={{subscriptionId}}&resourcetype=Azure.BlobContainer&resourcename={{container}}",
   "apiKey": "{{apiKey}}"
 }

--- a/src/modules/app/app-config.service.ts
+++ b/src/modules/app/app-config.service.ts
@@ -6,6 +6,7 @@ export interface AppConfig {
   catalogUrl: string;
   storageAccount: string;
   apiKey: string;
+  storageExplorerLinkTemplate: string;
 }
 
 @Injectable({

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -1,4 +1,15 @@
 <div id="wrapper" *ngIf="transferProcesses$ | async as transferProcesses">
+
+    <mat-card>
+      <div class="info-box">
+        <mat-icon>info</mat-icon>
+        <span class="text">Please install Storage Explorer for visualizing files transferred to Azure Blob Storage</span>
+        <span class="button">
+          <a mat-raised-button href="https://azure.microsoft.com/features/storage-explorer/">Install Azure Storage Explorer</a>
+        </span>
+      </div>
+    </mat-card>
+
     <mat-paginator [length]="transferProcesses.length" pageSize="transferProcesses.length" hidePageSize="true">
     </mat-paginator>
 

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -44,10 +44,10 @@
             <td mat-cell *matCellDef="let item">{{item.errorDetail}}</td>
         </ng-container>
 
-        <ng-container matColumnDef="link">
-          <th mat-header-cell *matHeaderCellDef scope="col">Link</th>
+        <ng-container matColumnDef="action">
+          <th mat-header-cell *matHeaderCellDef scope="col">Action</th>
           <td mat-cell *matCellDef="let item">
-            <a *ngIf="item.dataDestination.properties.type == 'AzureStorage'" mat-button color="accent" [href]="storageExplorerLinkTemplate | replace: item.dataDestination.properties | safe: 'url'">view</a>
+            <a *ngIf="item.dataDestination.properties.type == 'AzureStorage'" mat-button color="accent" [href]="storageExplorerLinkTemplate | replace: item.dataDestination.properties | safe: 'url'">Open Storage Explorer</a>
           </td>
         </ng-container>
 

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -4,11 +4,6 @@
 
     <table mat-table [dataSource]="transferProcesses" class="transfer-history-table">
 
-        <ng-container matColumnDef="stateTimestamp">
-            <th mat-header-cell *matHeaderCellDef scope="col">Timestamp</th>
-            <td mat-cell *matCellDef="let item" class="singleline-cell">{{item.stateTimestamp}}</td>
-        </ng-container>
-
         <ng-container matColumnDef="id">
             <th mat-header-cell *matHeaderCellDef scope="col">Id</th>
             <td mat-cell *matCellDef="let item">{{item.id}}</td>
@@ -47,6 +42,13 @@
         <ng-container matColumnDef="error">
             <th mat-header-cell *matHeaderCellDef scope="col">Error</th>
             <td mat-cell *matCellDef="let item">{{item.errorDetail}}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="link">
+          <th mat-header-cell *matHeaderCellDef scope="col">Link</th>
+          <td mat-cell *matCellDef="let item">
+            <a *ngIf="item.dataDestination.properties.type == 'AzureStorage'" mat-button color="accent" [href]="storageExplorerLinkTemplate | replace: item.dataDestination.properties | safe: 'url'">view</a>
+          </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="columns" class="transfer-history-table-header"></tr>

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.scss
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.scss
@@ -26,3 +26,18 @@ mat-paginator {
     display: inline-block;
     background-color: transparent;
 }
+
+.info-box {
+  display: flex;
+  align-items: center;
+
+  .text {
+    padding-left: 10px;
+  }
+
+  .button {
+    margin-left: auto;
+  }
+}
+
+

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
@@ -10,7 +10,7 @@ import {AppConfigService} from "../../../app/app-config.service";
 })
 export class TransferHistoryViewerComponent implements OnInit {
 
-  columns: string[] = ['id', 'type', 'state', 'connectorId', 'protocol', 'assetId', 'contractId', 'error', 'link'];
+  columns: string[] = ['id', 'type', 'state', 'connectorId', 'protocol', 'assetId', 'contractId', 'error', 'action'];
   transferProcesses$: Observable<TransferProcessDto[]> = of([]);
   storageExplorerLinkTemplate: string | undefined;
 

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {TransferProcessDto, TransferProcessService} from "../../../edc-dmgmt-client";
+import {AppConfigService} from "../../../app/app-config.service";
 
 @Component({
   selector: 'edc-demo-transfer-history',
@@ -9,12 +10,14 @@ import {TransferProcessDto, TransferProcessService} from "../../../edc-dmgmt-cli
 })
 export class TransferHistoryViewerComponent implements OnInit {
 
-  columns: string[] = ['stateTimestamp', 'id', 'type', 'state', 'connectorId', 'protocol', 'assetId', 'contractId', 'error'];
+  columns: string[] = ['id', 'type', 'state', 'connectorId', 'protocol', 'assetId', 'contractId', 'error', 'link'];
   transferProcesses$: Observable<TransferProcessDto[]> = of([]);
+  storageExplorerLinkTemplate: string | undefined;
 
-  constructor(private apiService: TransferProcessService) { }
+  constructor(private apiService: TransferProcessService, private appConfigService: AppConfigService) { }
 
   ngOnInit(): void {
     this.transferProcesses$ = this.apiService.getAllTransferProcesses();
+    this.storageExplorerLinkTemplate = this.appConfigService.getConfig()?.storageExplorerLinkTemplate
   }
 }

--- a/src/modules/edc-demo/edc-demo.module.ts
+++ b/src/modules/edc-demo/edc-demo.module.ts
@@ -35,6 +35,8 @@ import {
 } from './components/catalog-browser-transfer-dialog/catalog-browser-transfer-dialog.component';
 import {ContractViewerComponent} from './components/contract-viewer/contract-viewer.component';
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
+import {SafePipe} from "./pipes/safe.pipe";
+import {ReplacePipe} from "./pipes/replace.pipe";
 
 import {PolicyViewComponent} from "./components/policy-view/policy-view.component";
 import {
@@ -76,6 +78,10 @@ import {NewPolicyDialogComponent} from "./components/new-policy-dialog/new-polic
     IntroductionComponent,
     ContractDefinitionEditorDialog,
     CatalogBrowserTransferDialog,
+    ContractViewerComponent,
+    CatalogBrowserTransferDialog,
+    SafePipe,
+    ReplacePipe,
     PolicyViewComponent,
     PolicyRuleViewerComponent,
     CatalogBrowserTransferDialog,

--- a/src/modules/edc-demo/pipes/replace.pipe.ts
+++ b/src/modules/edc-demo/pipes/replace.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({name: 'replace'})
+export class ReplacePipe implements PipeTransform {
+  transform(value: string | undefined, replaceMap: { [key: string]: string; }): string | undefined {
+    if(!value || !replaceMap)
+    {
+      return value;
+    }
+
+    let result = value;
+    for(let [key,value] of Object.entries(replaceMap)){
+      result = result.replace(new RegExp(`\{\{${key}\}\}`, 'g'), value);
+    }
+
+    return result;
+  }
+}

--- a/src/modules/edc-demo/pipes/safe.pipe.ts
+++ b/src/modules/edc-demo/pipes/safe.pipe.ts
@@ -1,0 +1,21 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml, SafeStyle, SafeScript, SafeUrl, SafeResourceUrl } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safe'
+})
+export class SafePipe implements PipeTransform {
+
+  constructor(protected sanitizer: DomSanitizer) {}
+
+  public transform(value: any, type: string): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
+    switch (type) {
+      case 'html': return this.sanitizer.bypassSecurityTrustHtml(value);
+      case 'style': return this.sanitizer.bypassSecurityTrustStyle(value);
+      case 'script': return this.sanitizer.bypassSecurityTrustScript(value);
+      case 'url': return this.sanitizer.bypassSecurityTrustUrl(value);
+      case 'resourceUrl': return this.sanitizer.bypassSecurityTrustResourceUrl(value);
+      default: throw new Error(`Invalid safe type specified: ${type}`);
+    }
+  }
+}


### PR DESCRIPTION
closes agera-edc/DataDashboardFork#16 

Add storage explorer link to previous transfer list to visualize results:
- Button only present for AzureStorage transfers
- Storage explorer link in app.config.json of the form `storageexplorer://v=1&accountid=/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Storage/storageAccounts/{{account}}&subscriptionid={{subscriptionId}}&resourcetype=Azure.BlobContainer&resourcename={{container}}`
  - `account` and `container` are retrieved for each transfer process
  - the rest of variables are provided at provisioning time with terraform

Working sample (click on the completed transfer): http://378-company2-mvd.northeurope.azurecontainer.io/transfer-history-viewer