### PR TITLE
Randomized azure storage container name

### DIFF
--- a/src/modules/edc-demo/components/contract-viewer/contract-viewer.component.ts
+++ b/src/modules/edc-demo/components/contract-viewer/contract-viewer.component.ts
@@ -94,7 +94,7 @@ export class ContractViewerComponent implements OnInit {
           properties: {
             "type": storageTypeId,
             account: this.homeConnectorStorageAccount, // CAUTION: hardcoded value for AzureBlob
-            container: "dst-container", // CAUTION: hardcoded value for AzureBlob
+            // container: omitted, so it will be auto-assigned by the EDC runtime
           }
         },
         transferType: {isFinite: true}, //must be there, otherwise NPE on backend

--- a/src/modules/edc-demo/components/contract-viewer/contract-viewer.component.ts
+++ b/src/modules/edc-demo/components/contract-viewer/contract-viewer.component.ts
@@ -97,6 +97,7 @@ export class ContractViewerComponent implements OnInit {
             // container: omitted, so it will be auto-assigned by the EDC runtime
           }
         },
+        managedResources: true,
         transferType: {isFinite: true}, //must be there, otherwise NPE on backend
         connectorAddress: offeredAsset.originator
       };


### PR DESCRIPTION
The name of the destination blob container was hardcoded before (`dst-container`) and is now randomized by using a UUID string.

closes agera-edc/DataDashboardFork#15
