### PR TITLE
Feature: use `IN` expression when creating ContractDefs

### DIFF
--- a/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.html
+++ b/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.html
@@ -47,7 +47,7 @@
 
       <mat-divider inset></mat-divider>
       <mat-card-actions class="card-actions">
-        <button (click)="onDelete(asset)" [disabled]="isBusy()" color="accent" mat-stroked-button>
+        <button (click)="onDelete(asset)" [disabled]="isBusy()" color="warn" mat-stroked-button>
           <mat-icon>delete_sweep</mat-icon> Delete
         </button>
       </mat-card-actions>

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
@@ -8,7 +8,7 @@
     <div>
         <mat-form-field class="form-field form-field-policy" id="form-field-access-policy">
             <mat-label>Access policy</mat-label>
-            <mat-select [(ngModel)]="accessPolicy">
+            <mat-select [(ngModel)]="accessPolicy" required>
                 <mat-option *ngFor="let policy of policies" [value]="policy">
                     {{policy.uid}}
                 </mat-option>
@@ -17,7 +17,7 @@
 
         <mat-form-field class="form-field form-field-policy" id="form-field-contract-policy">
             <mat-label>Contract policy</mat-label>
-            <mat-select [(ngModel)]="contractPolicy">
+            <mat-select [(ngModel)]="contractPolicy" required>
                 <mat-option *ngFor="let policy of policies" [value]="policy">
                     {{policy.uid}}
                 </mat-option>

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
@@ -3,6 +3,7 @@ import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {AssetDto, AssetService, ContractDefinitionDto, Policy, PolicyService} from "../../../edc-dmgmt-client";
 import {flatMap, map, mergeMap} from "rxjs/operators";
 import {Asset} from "../../models/asset";
+import {expectEl} from "@angular/flex-layout/_private-utils/testing";
 
 
 @Component({
@@ -57,13 +58,15 @@ export class ContractDefinitionEditorDialog implements OnInit {
     this.contractDefinition.contractPolicyId = this.contractPolicy!.uid;
     this.contractDefinition.criteria = [];
 
-    this.assets.forEach(asset => {
+    const ids= this.assets.map(asset => asset.id);
+    const idExpr = `[${ids.join(",")}]`;
+
+
       this.contractDefinition.criteria = [...this.contractDefinition.criteria, {
         left: 'asset:prop:id',
-        op: '=',
-        right: asset.id,
+        op: 'in',
+        right: idExpr,
       }];
-    })
 
     this.dialogRef.close({
       "contractDefinition": this.contractDefinition

--- a/src/modules/edc-demo/components/contract-definition-viewer/contract-definition-viewer.component.html
+++ b/src/modules/edc-demo/components/contract-definition-viewer/contract-definition-viewer.component.html
@@ -72,7 +72,7 @@
 
             <mat-divider inset></mat-divider>
             <mat-card-actions class="card-actions">
-                <button (click)="onDelete(contractDefinition)" color="accent" mat-stroked-button>
+                <button (click)="onDelete(contractDefinition)" color="warn" mat-stroked-button>
                     <mat-icon>delete_sweep</mat-icon> Delete
                 </button>
             </mat-card-actions>


### PR DESCRIPTION
use the `IN` operator to select many assets: `asset:prop:id IN [id1,id2,id3]`. This is understood by all current asset index implementations.

_Note: updated "Delete" buttons to have a red color hue_