### PR TITLE
Fixes the `IN` operator

### DIFF
--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
@@ -59,13 +59,12 @@ export class ContractDefinitionEditorDialog implements OnInit {
     this.contractDefinition.criteria = [];
 
     const ids= this.assets.map(asset => asset.id);
-    const idExpr = `[${ids.join(",")}]`;
 
 
       this.contractDefinition.criteria = [...this.contractDefinition.criteria, {
         left: 'asset:prop:id',
         op: 'in',
-        right: idExpr,
+        right: ids,
       }];
 
     this.dialogRef.close({

--- a/src/modules/edc-dmgmt-client/model/criterion.ts
+++ b/src/modules/edc-dmgmt-client/model/criterion.ts
@@ -14,6 +14,6 @@
 export interface Criterion {
   left: string;
   op: string;
-  right: string;
+  right: string | object;
 }
 


### PR DESCRIPTION
the `IN` operator actually requires a list of objects rather than a formatted string.