### PR TITLE
Feature: add creation and lastupdate time to TransferHistory

### DIFF
--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -23,9 +23,19 @@
               <td mat-cell *matCellDef="let item">{{item.id}}</td>
           </ng-container>
 
+          <ng-container matColumnDef="creationDate">
+              <th mat-header-cell *matHeaderCellDef scope="col">Created</th>
+              <td mat-cell *matCellDef="let item">{{asDate(item.createdTimestamp)}}</td>
+          </ng-container>
+
           <ng-container matColumnDef="state">
               <th mat-header-cell *matHeaderCellDef scope="col">State</th>
               <td mat-cell *matCellDef="let item">{{item.state}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="lastUpdated">
+              <th mat-header-cell *matHeaderCellDef scope="col">Last updated</th>
+              <td mat-cell *matCellDef="let item">{{asDate(item.stateTimestamp)}}</td>
           </ng-container>
 
           <ng-container matColumnDef="connectorId">

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.ts
@@ -10,11 +10,12 @@ import {AppConfigService} from "../../../app/app-config.service";
 })
 export class TransferHistoryViewerComponent implements OnInit {
 
-  columns: string[] = ['id', 'state', 'connectorId', 'assetId', 'contractId', 'action'];
+  columns: string[] = ['id', 'creationDate', 'state', 'lastUpdated', 'connectorId', 'assetId', 'contractId', 'action'];
   transferProcesses$: Observable<TransferProcessDto[]> = of([]);
   storageExplorerLinkTemplate: string | undefined;
 
-  constructor(private transferProcessService: TransferProcessService, private appConfigService: AppConfigService) { }
+  constructor(private transferProcessService: TransferProcessService, private appConfigService: AppConfigService) {
+  }
 
   ngOnInit(): void {
     this.loadTransferProcesses();
@@ -35,5 +36,9 @@ export class TransferHistoryViewerComponent implements OnInit {
 
   loadTransferProcesses() {
     this.transferProcesses$ = this.transferProcessService.getAllTransferProcesses();
+  }
+
+  asDate(epochMillis?: number) {
+    return epochMillis ? new Date(epochMillis).toLocaleDateString() : '';
   }
 }

--- a/src/modules/edc-dmgmt-client/model/transferProcessDto.ts
+++ b/src/modules/edc-dmgmt-client/model/transferProcessDto.ts
@@ -9,16 +9,18 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { DataRequestDto } from './dataRequestDto';
-import { DataAddressInformationDto } from './dataAddressInformationDto';
+import {DataRequestDto} from './dataRequestDto';
+import {DataAddressInformationDto} from './dataAddressInformationDto';
 
 
 export interface TransferProcessDto {
-    id: string;
-    type: string;
-    state: string;
-    errorDetail?: string;
-    dataRequest: DataRequestDto;
-    dataDestination?: DataAddressInformationDto;
+  id: string;
+  type: string;
+  state: string;
+  errorDetail?: string;
+  dataRequest: DataRequestDto;
+  dataDestination?: DataAddressInformationDto;
+  createdTimestamp?: number; // epoch millis
+  stateTimestamp?: number; // epoch millis
 }
 


### PR DESCRIPTION
Adds two fields to the `TransferProcessDto`: `createdTimestamp?: number` and `stateTimestamp?: number` as well as two columns in the Transfer History viewer.

Closes agera-edc/DataDashboardFork#8 