### PR TITLE
Dynamic theming for dashboard

### DIFF
--- a/src/assets/config/app.config.json
+++ b/src/assets/config/app.config.json
@@ -4,5 +4,6 @@
   "catalogUrl": "{{catalogUrl}}",
   "storageAccount": "{{account}}",
   "storageExplorerLinkTemplate": "storageexplorer://v=1&accountid=/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Storage/storageAccounts/{{account}}&subscriptionid={{subscriptionId}}&resourcetype=Azure.BlobContainer&resourcename={{container}}",
-  "apiKey": "{{apiKey}}"
+  "apiKey": "{{apiKey}}",
+  "theme": "{{theme}}"
 }

--- a/src/modules/app/app-config.service.ts
+++ b/src/modules/app/app-config.service.ts
@@ -7,6 +7,7 @@ export interface AppConfig {
   storageAccount: string;
   apiKey: string;
   storageExplorerLinkTemplate: string;
+  theme: string;
 }
 
 @Injectable({

--- a/src/modules/app/app.component.html
+++ b/src/modules/app/app.component.html
@@ -1,1 +1,1 @@
-<app-navigation></app-navigation>
+<app-navigation [class]="themeClass()"></app-navigation>

--- a/src/modules/app/app.component.ts
+++ b/src/modules/app/app.component.ts
@@ -36,7 +36,7 @@ export class AppComponent implements OnInit {
       });
   }
 
-  themeClass(): string {
-    return this.configService.getConfig()?.theme || "";
+  themeClass(): string | undefined {
+    return this.configService.getConfig()?.theme;
   }
 }

--- a/src/modules/app/app.component.ts
+++ b/src/modules/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter, map } from 'rxjs/operators';
+import {AppConfigService} from "./app-config.service";
 
 @Component({
   selector: 'app-root',
@@ -13,6 +14,7 @@ export class AppComponent implements OnInit {
   constructor(
     private router: Router,
     private titleService: Title,
+    private configService: AppConfigService,
     private activatedRoute: ActivatedRoute) {
   }
 
@@ -32,5 +34,9 @@ export class AppComponent implements OnInit {
       ).subscribe((title: string) => {
         this.titleService.setTitle(title);
       });
+  }
+
+  themeClass(): string {
+    return this.configService.getConfig()?.theme || "";
   }
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -7,17 +7,51 @@
 @import "~@angular/material/theming";
 @include mat-core();
 
+//default theme {
 $theming-material-components-primary: mat-palette($mat-teal);
 $theming-material-components-accent: mat-palette($mat-orange, A200, A100, A400);
 $theming-material-components-warn: mat-palette($mat-red);
 
 $theming-material-components-theme: mat-dark-theme(
-  $theming-material-components-primary,
-  $theming-material-components-accent,
-  $theming-material-components-warn
+    $theming-material-components-primary,
+    $theming-material-components-accent,
+    $theming-material-components-warn
 );
 
 @include angular-material-theme($theming-material-components-theme);
+//}
+
+.theme-1 {
+  // use default
+}
+
+.theme-2 {
+  $theming-material-components-primary: mat-palette($mat-light-blue);
+  $theming-material-components-accent: mat-palette($mat-orange, A200, A100, A400);
+  $theming-material-components-warn: mat-palette($mat-red);
+
+  $theming-material-components-theme: mat-dark-theme(
+      $theming-material-components-primary,
+      $theming-material-components-accent,
+      $theming-material-components-warn
+  );
+
+  @include angular-material-theme($theming-material-components-theme);
+}
+
+.theme-3 {
+  $theming-material-components-primary: mat-palette($mat-light-green);
+  $theming-material-components-accent: mat-palette($mat-orange, A200, A100, A400);
+  $theming-material-components-warn: mat-palette($mat-red);
+
+  $theming-material-components-theme: mat-dark-theme(
+      $theming-material-components-primary,
+      $theming-material-components-accent,
+      $theming-material-components-warn
+  );
+
+  @include angular-material-theme($theming-material-components-theme);
+}
 
 $custom-typography: mat.define-typography-config($font-family: 'Open Sans');
 @include mat.core($custom-typography);


### PR DESCRIPTION
Dynamic theming for dashboard through the "theme" variable in `app.config.json`. Currently supporting 3 different themes:

## Theme 1
<img width="1184" alt="Screenshot 2022-05-27 at 14 31 00" src="https://user-images.githubusercontent.com/5342234/170699726-e2a24f66-a000-441a-a93c-4cb9b1e841ed.png">

## Theme 2
<img width="1136" alt="Screenshot 2022-05-27 at 14 31 22" src="https://user-images.githubusercontent.com/5342234/170699737-365c97d3-a34b-457d-a5c0-36db730a09b2.png">

## Theme 3
<img width="1241" alt="Screenshot 2022-05-27 at 14 31 33" src="https://user-images.githubusercontent.com/5342234/170699745-b3a52679-9616-41ca-823b-669ee5f20cc6.png">

