### PR TITLE
Fix reload on /assets

### DIFF
--- a/src/modules/app/app-routing.module.ts
+++ b/src/modules/app/app-routing.module.ts
@@ -46,7 +46,7 @@ export const routes: Routes = [
   {
     path: 'my-assets',
     component: AssetViewerComponent,
-    data: {title: 'My Assets', icon: 'upload'}
+    data: {title: 'Assets', icon: 'upload'}
   },
   {
     path: '', redirectTo: 'introduction', pathMatch: 'full'

--- a/src/modules/app/app-routing.module.ts
+++ b/src/modules/app/app-routing.module.ts
@@ -44,7 +44,7 @@ export const routes: Routes = [
     data: {title: 'Policies', icon: 'policy'}
   },
   {
-    path: 'my-assets',
+    path: 'my-assets', // must not be "assets" to prevent conflict with assets directory
     component: AssetViewerComponent,
     data: {title: 'Assets', icon: 'upload'}
   },

--- a/src/modules/app/app-routing.module.ts
+++ b/src/modules/app/app-routing.module.ts
@@ -44,9 +44,9 @@ export const routes: Routes = [
     data: {title: 'Policies', icon: 'policy'}
   },
   {
-    path: 'assets',
+    path: 'my-assets',
     component: AssetViewerComponent,
-    data: {title: 'Assets', icon: 'upload'}
+    data: {title: 'My Assets', icon: 'upload'}
   },
   {
     path: '', redirectTo: 'introduction', pathMatch: 'full'

--- a/src/modules/edc-demo/components/introduction/introduction.component.html
+++ b/src/modules/edc-demo/components/introduction/introduction.component.html
@@ -54,7 +54,7 @@
         <li>View your existing contracts in the <a [routerLink]="['/contracts']">Contracts</a> page</li>
         <li>Transfer an asset in your Dataspace using the <a [routerLink]="['/contracts']">Contracts</a> page</li>
         <li>View which assets have been transferred in your Dataspace in the <a [routerLink]="['/transfer-history']">Transfer History</a> page</li>
-        <li>View and create assets using the <a [routerLink]="['/assets']">Assets</a> page</li>
+        <li>View and create assets using the <a [routerLink]="['/my-assets']">Assets</a> page</li>
         <li>View and create policies and apply these to assets in your Dataspace using the <a [routerLink]="['/policies']">Policies</a> page</li>
         <li>Publish a new asset into your Dataspace using the <a [routerLink]="['/contract-definitions']">Contract Definitions</a> page</li>
       </ul>


### PR DESCRIPTION
Rename /assets route to prevent conflict with /assets directory on the web server which was causing issues on reload.